### PR TITLE
:wrench: replaces wrench with calls to fs-plus

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
   "devDependencies": {
     "coffeelint": "1.16.0",
     "coffeescope2": "0.4.3",
-    "temp": "0.8.3",
-    "wrench": "1.5.9"
+    "temp": "0.8.3"
   },
   "package-deps": [
     "language-dot"

--- a/spec/graphviz-preview-plus-view-spec.coffee
+++ b/spec/graphviz-preview-plus-view-spec.coffee
@@ -1,7 +1,6 @@
 path             = require 'path'
 fs               = require 'fs-plus'
 temp             = require 'temp'
-wrench           = require 'wrench'
 GraphVizPreviewView = require '../lib/graphviz-preview-plus-view'
 grammarHelper    = require './grammarHelper'
 
@@ -74,7 +73,7 @@ describe "graphviz preview plus package view", ->
     beforeEach ->
       fixturesPath = path.join(__dirname, 'fixtures')
       tempPath = temp.mkdirSync('atom')
-      wrench.copyDirSyncRecursive(fixturesPath, tempPath, forceDelete: true)
+      fs.copySync(fixturesPath, tempPath)
       atom.project.setPaths([tempPath])
 
       jasmine.useRealClock()
@@ -106,7 +105,7 @@ describe "graphviz preview plus package view", ->
     beforeEach ->
       fixturesPath = path.join(__dirname, 'fixtures')
       tempPath = temp.mkdirSync('atom')
-      wrench.copyDirSyncRecursive(fixturesPath, tempPath, forceDelete: true)
+      fs.copySync(fixturesPath, tempPath)
       atom.project.setPaths([tempPath])
 
       jasmine.useRealClock()
@@ -150,7 +149,6 @@ describe "graphviz preview plus package view", ->
     it "graphviz-preview-plus:zoom-to-fit zooms to fit", ->
       atom.commands.dispatch previewPaneItem.element, 'graphviz-preview-plus:zoom-to-fit'
       lSvg = previewPaneItem.imageContainer.find('svg')[0]
-      console.log lSvg.getAttribute('width')
       expect(lSvg.style.zoom).toBe '1'
       expect(lSvg.getAttribute('width')).toBe '100%'
 
@@ -158,7 +156,7 @@ describe "graphviz preview plus package view", ->
     beforeEach ->
       fixturesPath = path.join(__dirname, 'fixtures')
       tempPath = temp.mkdirSync('atom')
-      wrench.copyDirSyncRecursive(fixturesPath, tempPath, forceDelete: true)
+      fs.copySync(fixturesPath, tempPath)
       atom.project.setPaths([tempPath])
 
       jasmine.useRealClock()

--- a/spec/main-spec.coffee
+++ b/spec/main-spec.coffee
@@ -1,7 +1,6 @@
 path                = require 'path'
 fs                  = require 'fs-plus'
 temp                = require 'temp'
-wrench              = require 'wrench'
 GraphVizPreviewView = require '../lib/graphviz-preview-plus-view'
 grammarHelper       = require './grammarHelper'
 
@@ -13,7 +12,7 @@ describe "graphviz preview plus package main", ->
 
     fixturesPath = path.join(__dirname, 'fixtures')
     tempPath = temp.mkdirSync('atom')
-    wrench.copyDirSyncRecursive(fixturesPath, tempPath, forceDelete: true)
+    fs.copySync(fixturesPath, tempPath)
     atom.project.setPaths([tempPath])
 
     jasmine.useRealClock()


### PR DESCRIPTION
- wrench is deprecated (source: https://github.com/ryanmcgrath/wrench-js)
- fs-plus (already a dev dependency) has a recursive directory copy as well
