### PR TITLE
Emit a warning when attempting to export a too big graph to png

### DIFF
--- a/lib/graphviz-preview-plus-view.js
+++ b/lib/graphviz-preview-plus-view.js
@@ -60,10 +60,12 @@ export default class GraphVizPreviewView extends ScrollView {
                 });
                 this.div({
                     "class": 'image-controls-group btn-group'
-                }, () => this.button({
-                    "class": 'btn',
-                    outlet: 'zoomToFitButton'
-                }, 'Zoom to fit'));
+                }, () => {
+                    this.button({
+                        "class": 'btn',
+                        outlet: 'zoomToFitButton'
+                    }, 'Zoom to fit');
+                });
             });
             this.div({
                 "class": 'image-container',
@@ -283,8 +285,8 @@ export default class GraphVizPreviewView extends ScrollView {
             lRetval = path.dirname(this.editor.getPath().toString());
         } else if (Boolean(atom.project) && Boolean(atom.project.getPaths())) {
             /*
-             * when there is no editorPath, it might be a buffer. A
-             * a path from the project is a logical choice then=> choosing
+             * when there is no editorPath, it might be a buffer.
+             * A path from the project is a logical choice then => choosing
              * the first path here as a best guess.
              */
             lRetval = atom.project.getPaths()[0];
@@ -500,9 +502,22 @@ export default class GraphVizPreviewView extends ScrollView {
                 if (svgToRaster === null) {
                     svgToRaster = require('./svgToRaster');
                 }
-                svgToRaster(this.svg, pResult => {
-                    fs.writeFileSync(outputFilePath, pResult);
-                    return atom.workspace.open(outputFilePath);
+                svgToRaster(this.svg, (pResult, pError) => {
+                    if (Boolean(pError)) {
+                        atom.notifications.addError(
+                            "Too big to export",
+                            {
+                                detail: `Atom cannot export this graph to PNG because it is too big
+for that. If you want a PNG out of this graph your best
+option at the moment is to use the GraphViz command line:
+    dot -T png -o yourgraph.png yourgraph.dot`,
+                                dismissable: true
+                            }
+                        );
+                    } else {
+                        fs.writeFileSync(outputFilePath, pResult);
+                        atom.workspace.open(outputFilePath);
+                    }
                 });
             } else {
                 fs.writeFileSync(outputFilePath, this.svg);

--- a/lib/svgToRaster.js
+++ b/lib/svgToRaster.js
@@ -1,4 +1,5 @@
 "use babel";
+const MAX_SIGNED_SHORT = 32767;
 
 /**
  * Transforms the given svg to a raster graphic.
@@ -22,27 +23,34 @@ export default function (pSVG, pCallback, pRasterType = 'image/png') {
     lImg.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(pSVG)}`;
 
     lImg.addEventListener('load', function (pEvent) {
-
-        // create an (undisplayed) canvas
-        const lCanvas = document.createElement('canvas');
         const lImage  = pEvent.target;
 
-        // resize the canvas to the size of the image
-        lCanvas.width  = lImage.width;
-        lCanvas.height = lImage.height;
+        if (lImage.width > MAX_SIGNED_SHORT || lImage.height > MAX_SIGNED_SHORT) {
+            // We're using canvas - which can handle ~32kx32k bitmaps,
+            // but (in v8) not bigger ones
+            pCallback(null, new Error("image-too-big"));
+        } else {
+            // create an (undisplayed) canvas
+            const lCanvas = document.createElement('canvas');
 
-        // ... and draw the image on there
-        lCanvas.getContext('2d').drawImage(lImage, 0, 0);
+            // resize the canvas to the size of the image
+            lCanvas.width  = lImage.width;
+            lCanvas.height = lImage.height;
 
-        // smurf the data url of the canvas
-        const lDataURL = lCanvas.toDataURL(pRasterType, 0.8);
+            // ... and draw the image on there
+            lCanvas.getContext('2d').drawImage(lImage, 0, 0);
 
-        // extract the base64 encoded image, decode and return it
-        pCallback(
-            Buffer.from(
-                lDataURL.replace(`data:${pRasterType};base64,`, ''),
-                'base64'
-            )
-        );
+            // smurf the data url of the canvas
+            const lDataURL = lCanvas.toDataURL(pRasterType, 0.8);
+
+            // extract the base64 encoded image, decode and return it
+            pCallback(
+                Buffer.from(
+                    lDataURL.replace(`data:${pRasterType};base64,`, ''),
+                    'base64'
+                )
+            );
+        }
+
     });
 }


### PR DESCRIPTION
We're using canvas for converting the svg to png - the canvas can only hold a limited size picture (max 32kx32k as it seems in v8), so we can only export svg's that at are at most that size. This change makes atom emit an error when the user tries to do so.