### PR TITLE
Adds fit to width and fit to height commands

### DIFF
--- a/keymaps/graphviz-preview-plus.json
+++ b/keymaps/graphviz-preview-plus.json
@@ -8,7 +8,9 @@
     "cmd--": "graphviz-preview-plus:zoom-out",
     "cmd-_": "graphviz-preview-plus:zoom-out",
     "cmd-0": "graphviz-preview-plus:reset-zoom",
-    "cmd-9": "graphviz-preview-plus:zoom-to-fit"
+    "cmd-9": "graphviz-preview-plus:zoom-to-fit",
+    "cmd-8": "graphviz-preview-plus:zoom-to-width",
+    "cmd-7": "graphviz-preview-plus:zoom-to-height"
   },
   ".platform-win32 .graphviz-preview-plus, .platform-linux .graphviz-preview-plus": {
     "ctrl-+": "graphviz-preview-plus:zoom-in",
@@ -16,6 +18,8 @@
     "ctrl--": "graphviz-preview-plus:zoom-out",
     "ctrl-_": "graphviz-preview-plus:zoom-out",
     "ctrl-0": "graphviz-preview-plus:reset-zoom",
-    "ctrl-9": "graphviz-preview-plus:zoom-to-fit"
+    "ctrl-9": "graphviz-preview-plus:zoom-to-fit",
+    "ctrl-8": "graphviz-preview-plus:zoom-to-width",
+    "ctrl-7": "graphviz-preview-plus:zoom-to-height"
   }
 }

--- a/lib/graphviz-preview-plus-view.js
+++ b/lib/graphviz-preview-plus-view.js
@@ -603,12 +603,10 @@ option at the moment is to use the GraphViz command line:
         if (!(this.loaded && this.isVisible())) {
             return;
         }
-        this.setZoom(1);
+        this.setZoom(this.determineZoomToFitFactor());
         this.mode = 'zoom-to-fit';
         this.imageContainer.addClass('zoom-to-fit');
         this.zoomToFitButton.addClass('selected');
-        this.renderedSVG.attr('width', '100%');
-        this.renderedSVG.attr('height', this.renderedSVG[0].clientHeight * this.determineZoomToFitFactor());
         this.resetZoomButton.text('Auto');
     }
 
@@ -622,6 +620,9 @@ option at the moment is to use the GraphViz command line:
     }
 
     zoomToHeight() {
+        if (!(this.loaded && this.isVisible())) {
+            return;
+        }
         this.setZoom(this.imageContainer.context.clientHeight / this.renderedSVG[0].clientHeight);
         this.resetZoomButton.text('Auto');
         this.zoomToFitButton.removeClass('selected');

--- a/lib/graphviz-preview-plus-view.js
+++ b/lib/graphviz-preview-plus-view.js
@@ -618,11 +618,13 @@ option at the moment is to use the GraphViz command line:
         }
         this.setZoom(this.imageContainer.context.clientWidth / this.renderedSVG[0].clientWidth);
         this.resetZoomButton.text('Auto');
+        this.zoomToFitButton.removeClass('selected');
     }
 
     zoomToHeight() {
         this.setZoom(this.imageContainer.context.clientHeight / this.renderedSVG[0].clientHeight);
         this.resetZoomButton.text('Auto');
+        this.zoomToFitButton.removeClass('selected');
     }
 
     changeBackground(color) {

--- a/lib/graphviz-preview-plus-view.js
+++ b/lib/graphviz-preview-plus-view.js
@@ -243,7 +243,9 @@ export default class GraphVizPreviewView extends ScrollView {
             'graphviz-preview-plus:zoom-in': () => this.zoomIn(),
             'graphviz-preview-plus:zoom-out': () => this.zoomOut(),
             'graphviz-preview-plus:reset-zoom': () => this.resetZoom(),
-            'graphviz-preview-plus:zoom-to-fit': () => this.zoomToFit()
+            'graphviz-preview-plus:zoom-to-fit': () => this.zoomToFit(),
+            'graphviz-preview-plus:zoom-to-width': () => this.zoomToWidth(),
+            'graphviz-preview-plus:zoom-to-height': () => this.zoomToHeight()
         });
         const changeHandler = () => {
             this.renderDot();
@@ -607,6 +609,19 @@ option at the moment is to use the GraphViz command line:
         this.zoomToFitButton.addClass('selected');
         this.renderedSVG.attr('width', '100%');
         this.renderedSVG.attr('height', this.renderedSVG[0].clientHeight * this.determineZoomToFitFactor());
+        this.resetZoomButton.text('Auto');
+    }
+
+    zoomToWidth() {
+        if (!(this.loaded && this.isVisible())) {
+            return;
+        }
+        this.setZoom(this.imageContainer.context.clientWidth / this.renderedSVG[0].clientWidth);
+        this.resetZoomButton.text('Auto');
+    }
+
+    zoomToHeight() {
+        this.setZoom(this.imageContainer.context.clientHeight / this.renderedSVG[0].clientHeight);
         this.resetZoomButton.text('Auto');
     }
 

--- a/menus/graphviz-preview-plus.json
+++ b/menus/graphviz-preview-plus.json
@@ -86,7 +86,28 @@
             "command": "graphviz-preview-plus:engine-twopi"
           }
         ]
-      }
+    },
+    {
+      "label": "Zoom",
+      "submenu": [
+        {
+          "label": "to fit",
+          "command": "graphviz-preview-plus:zoom-to-fit"
+        },
+        {
+          "label": "to width",
+          "command": "graphviz-preview-plus:zoom-to-width"
+        },
+        {
+          "label": "to height",
+          "command": "graphviz-preview-plus:zoom-to-height"
+        },
+        {
+          "label": "reset",
+          "command": "graphviz-preview-plus:reset-zoom"
+        }
+      ]
+    }
     ]
   }
 }

--- a/spec/graphviz-preview-plus-view-spec.js
+++ b/spec/graphviz-preview-plus-view-spec.js
@@ -162,16 +162,20 @@ describe("graphviz preview plus package view", () => {
             expect(lSvg.style.zoom).toBe('1');
             expect(lSvg.getAttribute('width')).toBe('199pt');
         });
-        it("graphviz-preview-plus:zoom-to-fit zooms to fit", () => {
+        fit("graphviz-preview-plus:zoom-to-fit zooms to fit", () => {
             atom.commands.dispatch(previewPaneItem.element, 'graphviz-preview-plus:zoom-to-fit');
             const lSvg = previewPaneItem.imageContainer.find('svg')[0];
-            expect(lSvg.style.zoom).toBe('1');
-            expect(lSvg.getAttribute('width')).toBe('100%');
+            expect(parseInt(lSvg.style.zoom, 10)).toBe(0);
+            expect(lSvg.getAttribute('width')).toBe('199pt');
         });
         it("graphviz-preview-plus:zoom-to-width zooms to width", () => {
             atom.commands.dispatch(previewPaneItem.element, 'graphviz-preview-plus:zoom-to-width');
             const lSvg = previewPaneItem.imageContainer.find('svg')[0];
-            expect(lSvg.style.zoom).toBeGreaterThan('1.3'); // the actual zoom factor depends on the platform
+
+            // the actual zoom factor depends on the platform, so
+            // putting an exact number here will make it pass on one
+            // and fail on other platforms
+            expect(parseInt(lSvg.style.zoom, 10)).toBeGreaterThan(1.3);
         });
         it("graphviz-preview-plus:zoom-to-height zooms to height", () => {
             atom.commands.dispatch(previewPaneItem.element, 'graphviz-preview-plus:zoom-to-height');

--- a/spec/graphviz-preview-plus-view-spec.js
+++ b/spec/graphviz-preview-plus-view-spec.js
@@ -134,32 +134,49 @@ describe("graphviz preview plus package view", () => {
             atom.commands.dispatch(previewPaneItem.element, 'graphviz-preview-plus:zoom-in');
             atom.commands.dispatch(previewPaneItem.element, 'graphviz-preview-plus:zoom-in');
             const lSvg = previewPaneItem.imageContainer.find('svg')[0];
-            return expect(lSvg.style.zoom).toBe('1.3');
+            expect(lSvg.style.zoom).toBe('1.3');
         });
         it("2x graphviz-preview-plus:zoom-out decreases the image size by 20%", () => {
             atom.commands.dispatch(previewPaneItem.element, 'graphviz-preview-plus:zoom-out');
             atom.commands.dispatch(previewPaneItem.element, 'graphviz-preview-plus:zoom-out');
             const lSvg = previewPaneItem.imageContainer.find('svg')[0];
-            return expect(lSvg.style.zoom).toBe('0.8');
+            expect(lSvg.style.zoom).toBe('0.8');
         });
         it("graphviz-preview-plus:reset-zoom resets zoom after size change", () => {
             atom.commands.dispatch(previewPaneItem.element, 'graphviz-preview-plus:zoom-out');
             atom.commands.dispatch(previewPaneItem.element, 'graphviz-preview-plus:reset-zoom');
             const lSvg = previewPaneItem.imageContainer.find('svg')[0];
-            return expect(lSvg.style.zoom).toBe('1');
+            expect(lSvg.style.zoom).toBe('1');
         });
         it("graphviz-preview-plus:reset-zoom resets zoom after zoom-to-fit", () => {
             atom.commands.dispatch(previewPaneItem.element, 'graphviz-preview-plus:zoom-to-fit');
             atom.commands.dispatch(previewPaneItem.element, 'graphviz-preview-plus:reset-zoom');
             const lSvg = previewPaneItem.imageContainer.find('svg')[0];
             expect(lSvg.style.zoom).toBe('1');
-            return expect(lSvg.getAttribute('width')).toBe('199pt');
+            expect(lSvg.getAttribute('width')).toBe('199pt');
+        });
+        it("graphviz-preview-plus:reset-zoom resets zoom after zoom-to-width", () => {
+            atom.commands.dispatch(previewPaneItem.element, 'graphviz-preview-plus:zoom-to-width');
+            atom.commands.dispatch(previewPaneItem.element, 'graphviz-preview-plus:reset-zoom');
+            const lSvg = previewPaneItem.imageContainer.find('svg')[0];
+            expect(lSvg.style.zoom).toBe('1');
+            expect(lSvg.getAttribute('width')).toBe('199pt');
         });
         it("graphviz-preview-plus:zoom-to-fit zooms to fit", () => {
             atom.commands.dispatch(previewPaneItem.element, 'graphviz-preview-plus:zoom-to-fit');
             const lSvg = previewPaneItem.imageContainer.find('svg')[0];
             expect(lSvg.style.zoom).toBe('1');
-            return expect(lSvg.getAttribute('width')).toBe('100%');
+            expect(lSvg.getAttribute('width')).toBe('100%');
+        });
+        it("graphviz-preview-plus:zoom-to-width zooms to width", () => {
+            atom.commands.dispatch(previewPaneItem.element, 'graphviz-preview-plus:zoom-to-width');
+            const lSvg = previewPaneItem.imageContainer.find('svg')[0];
+            expect(lSvg.style.zoom).toBe('1.50376');
+        });
+        it("graphviz-preview-plus:zoom-to-height zooms to height", () => {
+            atom.commands.dispatch(previewPaneItem.element, 'graphviz-preview-plus:zoom-to-height');
+            const lSvg = previewPaneItem.imageContainer.find('svg')[0];
+            expect(lSvg.style.zoom).toBe('0');
         });
     });
     describe("when core:save-as is triggered", () => {

--- a/spec/graphviz-preview-plus-view-spec.js
+++ b/spec/graphviz-preview-plus-view-spec.js
@@ -162,7 +162,7 @@ describe("graphviz preview plus package view", () => {
             expect(lSvg.style.zoom).toBe('1');
             expect(lSvg.getAttribute('width')).toBe('199pt');
         });
-        fit("graphviz-preview-plus:zoom-to-fit zooms to fit", () => {
+        it("graphviz-preview-plus:zoom-to-fit zooms to fit", () => {
             atom.commands.dispatch(previewPaneItem.element, 'graphviz-preview-plus:zoom-to-fit');
             const lSvg = previewPaneItem.imageContainer.find('svg')[0];
             expect(parseInt(lSvg.style.zoom, 10)).toBe(0);

--- a/spec/graphviz-preview-plus-view-spec.js
+++ b/spec/graphviz-preview-plus-view-spec.js
@@ -165,7 +165,7 @@ describe("graphviz preview plus package view", () => {
         it("graphviz-preview-plus:zoom-to-fit zooms to fit", () => {
             atom.commands.dispatch(previewPaneItem.element, 'graphviz-preview-plus:zoom-to-fit');
             const lSvg = previewPaneItem.imageContainer.find('svg')[0];
-            expect(parseInt(lSvg.style.zoom, 10)).toBe(0);
+            expect(parseFloat(lSvg.style.zoom, 10)).toBe(0);
             expect(lSvg.getAttribute('width')).toBe('199pt');
         });
         it("graphviz-preview-plus:zoom-to-width zooms to width", () => {
@@ -175,7 +175,7 @@ describe("graphviz preview plus package view", () => {
             // the actual zoom factor depends on the platform, so
             // putting an exact number here will make it pass on one
             // and fail on other platforms
-            expect(parseInt(lSvg.style.zoom, 10)).toBeGreaterThan(1.3);
+            expect(parseFloat(lSvg.style.zoom, 10)).toBeGreaterThan(1.3);
         });
         it("graphviz-preview-plus:zoom-to-height zooms to height", () => {
             atom.commands.dispatch(previewPaneItem.element, 'graphviz-preview-plus:zoom-to-height');

--- a/spec/graphviz-preview-plus-view-spec.js
+++ b/spec/graphviz-preview-plus-view-spec.js
@@ -171,7 +171,7 @@ describe("graphviz preview plus package view", () => {
         it("graphviz-preview-plus:zoom-to-width zooms to width", () => {
             atom.commands.dispatch(previewPaneItem.element, 'graphviz-preview-plus:zoom-to-width');
             const lSvg = previewPaneItem.imageContainer.find('svg')[0];
-            expect(lSvg.style.zoom).toBe('1.50376');
+            expect(lSvg.style.zoom).toBeGreaterThan('1.3'); // the actual zoom factor depends on the platform
         });
         it("graphviz-preview-plus:zoom-to-height zooms to height", () => {
             atom.commands.dispatch(previewPaneItem.element, 'graphviz-preview-plus:zoom-to-height');


### PR DESCRIPTION
## Description
Adds 'fit to width' and 'fit to height' commands as 
- atom actions (with shortcut keys)
- context menu options

The (new) 'Zoom' context menu also contains the (already existing) 'zoom to fit' and 'reset zoom' actions.

## Motivation and Context
Fixes #21 

## How Has This Been Tested?
Unit tests! (And manually)

## Screenshots:
![fit-to-width](https://user-images.githubusercontent.com/4822597/32102262-dd44abb8-bb1b-11e7-91b1-73981c8262a1.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- ~~~Bug fix (non-breaking change which fixes an issue)~~~
- [x] New feature (non-breaking change which adds functionality)
- ~~~Breaking change (fix or feature that would cause existing functionality to change)~~~

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.