### PR TITLE
feat(preview): makes links in rendered preview clickable

### DIFF
--- a/lib/graphviz-preview-plus-view.js
+++ b/lib/graphviz-preview-plus-view.js
@@ -356,8 +356,30 @@ export default class GraphVizPreviewView extends ScrollView {
         // however that (jQuery) function executes a toLowerCase (or similar),
         // As svg attributes are case sensitive this doesn't have any effect.
         // Hence direct DOM manipulation:
-        const pRenderedSVGDOMElement = pRenderedSVG.get()[0];
-        pRenderedSVGDOMElement.setAttribute("viewBox", `0 0 ${lWidth} ${lHeight}`);
+        const lRenderedSVGDOMElement = pRenderedSVG.get()[0];
+        lRenderedSVGDOMElement.setAttribute("viewBox", `0 0 ${lWidth} ${lHeight}`);
+    }
+
+    /**
+     * Usualy links in html in atom preview windows are clickable. However,
+     * correct links in svg (in the xlink namespace) aren't, whereas other
+     * browser implementations do.
+     *
+     * This is a workaround for that limitation. It adds a `href` attribute
+     * to each `a` in the svg in the preview window (_not_ to the exported svg!)
+     * that has an`xlink:href` attribute.
+     *
+     * @param  {object} pRenderedSVG the (jQuery object wrapped) SVG as rendered
+     *                               by GraphViz
+     * @return {nothing}             This function _directly_ manipulates the
+     *                               input SVG
+     */
+    makeLinksClickable(pRenderedSVG) {
+        pRenderedSVG.find("a").each(function() {
+            if (Boolean(this.getAttribute("xlink:href"))) {
+                this.setAttribute("href", this.getAttribute("xlink:href"));
+            }
+        });
     }
 
     renderDotText(pText, pWorkingDirectory) {
@@ -378,7 +400,10 @@ export default class GraphVizPreviewView extends ScrollView {
 
                 this.imageContainer.html(pSvg);
                 this.renderedSVG = this.imageContainer.find('svg');
+                /* start workarounds */
                 this.correctViewBox(this.renderedSVG);
+                this.makeLinksClickable(this.renderedSVG);
+                /* end workarounds */
                 this.svg = this.renderedSVG[0].outerHTML;
 
                 this.originalWidth = this.renderedSVG.attr('width');
@@ -396,6 +421,7 @@ export default class GraphVizPreviewView extends ScrollView {
                 } else {
                     this.setZoom(this.zoomFactor);
                 }
+
                 this.emitter.emit('did-change-graphviz');
                 return this.originalTrigger('graphviz-preview-plus:dot-changed');
             }


### PR DESCRIPTION
- in atom preview windows regular links work (clickable, opens the link)
- proper svg links (in the xlink namespace) don't (yet - I gather)

This workaround adds a `href` attribute to all `a` elements with (but
only in the preview window - not if you export the svg)

Fixes #25 

_Because there are never enough opportunities for rick-rolling_