### PR TITLE
Make png/ svg exports also work when generated output contains &nbsp; entities

### DIFF
--- a/lib/graphviz-preview-plus-view.js
+++ b/lib/graphviz-preview-plus-view.js
@@ -1,5 +1,4 @@
 "use babel";
-
 import {Emitter, Disposable, CompositeDisposable, File} from 'atom';
 import {$, $$$, ScrollView} from 'atom-space-pen-views';
 import path from 'path';
@@ -9,7 +8,7 @@ import fs from 'fs-plus';
 let renderGraphViz = null;
 let renderError = null;
 let svgToRaster = null;
-let resolveImage = null;
+let workarounds = null;
 
 let latestKnownEditorId = null;
 
@@ -320,68 +319,6 @@ export default class GraphVizPreviewView extends ScrollView {
         }
     }
 
-    resolveImages(pRenderedSVG, pWorkingDirectory) {
-        const lImages = pRenderedSVG.find('image');
-        if (Boolean(lImages) && resolveImage === null) {
-            resolveImage = require('./resolveImage');
-        }
-        for (let i = 0; i < lImages.length; i++) {
-            lImages[i].href.baseVal = resolveImage(lImages[i].href.baseVal, pWorkingDirectory);
-        }
-    }
-    /**
-     * GraphViz incorrectly renders SVG's in case there's a dpi !== the
-     * default (72) in the input dot. Root cause is that the viewBox doesn't
-     * get resized, while width, height and the main `g`'s scale are.
-     *
-     * This function corrects that by setting the viewBox to the width and
-     * height of the svg.
-     *
-     * Additional complexity: GraphViz uses pt as unit in the width & height.
-     * It uses those numbers 1:1 width & height in the viewBox. However, viewBox
-     * unit's are not points. So the SVG GraphViz outputs is always slightly
-     * bigger than it should be. graphviz-preview-plus does not interfere in
-     * that behavior.
-     *
-     * @param  {object} pRenderedSVG the (jQuery object wrapped) SVG as rendered
-     *                               by GraphViz
-     * @return {nothing}             This function _directly_ manipulates the
-     *                               input SVG
-     */
-    correctViewBox(pRenderedSVG) {
-        const lWidth = Number.parseFloat(pRenderedSVG.attr("width"));
-        const lHeight = Number.parseFloat(pRenderedSVG.attr("height"));
-
-        // should have been able to use pRenderedSVG.attr to set the viewBox,
-        // however that (jQuery) function executes a toLowerCase (or similar),
-        // As svg attributes are case sensitive this doesn't have any effect.
-        // Hence direct DOM manipulation:
-        const lRenderedSVGDOMElement = pRenderedSVG.get()[0];
-        lRenderedSVGDOMElement.setAttribute("viewBox", `0 0 ${lWidth} ${lHeight}`);
-    }
-
-    /**
-     * Usualy links in html in atom preview windows are clickable. However,
-     * correct links in svg (in the xlink namespace) aren't, whereas other
-     * browser implementations do.
-     *
-     * This is a workaround for that limitation. It adds a `href` attribute
-     * to each `a` in the svg in the preview window (_not_ to the exported svg!)
-     * that has an`xlink:href` attribute.
-     *
-     * @param  {object} pRenderedSVG the (jQuery object wrapped) SVG as rendered
-     *                               by GraphViz
-     * @return {nothing}             This function _directly_ manipulates the
-     *                               input SVG
-     */
-    makeLinksClickable(pRenderedSVG) {
-        pRenderedSVG.find("a").each(function() {
-            if (Boolean(this.getAttribute("xlink:href"))) {
-                this.setAttribute("href", this.getAttribute("xlink:href"));
-            }
-        });
-    }
-
     renderDotText(pText, pWorkingDirectory) {
         if (latestKnownEditorId !== this.editorId) {
             latestKnownEditorId = this.editorId;
@@ -396,20 +333,23 @@ export default class GraphVizPreviewView extends ScrollView {
             } else {
                 this.loading = false;
                 this.loaded = true;
-                this.svg = pSvg;
+                if (workarounds === null) {
+                    workarounds = require('./workarounds');
+                }
 
                 this.imageContainer.html(pSvg);
                 this.renderedSVG = this.imageContainer.find('svg');
-                /* start workarounds */
-                this.correctViewBox(this.renderedSVG);
-                this.makeLinksClickable(this.renderedSVG);
-                /* end workarounds */
-                this.svg = this.renderedSVG[0].outerHTML;
+                workarounds.correctViewBox(this.renderedSVG);
+                this.svg = workarounds.defineEntities(this.renderedSVG[0].outerHTML);
+
+                // this workaround only for the svg in the preview window
+                // ... not in the exported one
+                workarounds.makeLinksClickable(this.renderedSVG);
 
                 this.originalWidth = this.renderedSVG.attr('width');
                 this.originalHeight = this.renderedSVG.attr('height');
                 if (Boolean(pWorkingDirectory)) {
-                    this.resolveImages(this.renderedSVG, pWorkingDirectory);
+                    workarounds.resolveImages(this.renderedSVG, pWorkingDirectory);
                 }
 
                 if (this.mode === 'zoom-to-fit') {

--- a/lib/resolveImage.js
+++ b/lib/resolveImage.js
@@ -1,9 +1,8 @@
 "use babel";
-import * as path from 'path';
+import path from 'path';
 
 const imagePathIsAbsolute = (pImagePath) =>
     pImagePath.startsWith('/') || pImagePath.match(/^(https?|atom|file):\/\//);
-
 
 /**
  * resolves the given path to an image (in pImagePath) following these rules

--- a/lib/workarounds.js
+++ b/lib/workarounds.js
@@ -1,0 +1,104 @@
+"use babel";
+
+let resolveImage = null;
+
+/**
+ * GraphViz incorrectly renders SVG's in case there's a dpi !== the
+ * default (72) in the input dot. Root cause is that the viewBox doesn't
+ * get resized, while width, height and the main `g`'s scale are.
+ *
+ * This function corrects that by setting the viewBox to the width and
+ * height of the svg.
+ *
+ * Additional complexity: GraphViz uses pt as unit in the width & height.
+ * It uses those numbers 1:1 width & height in the viewBox. However, viewBox
+ * unit's are not points. So the SVG GraphViz outputs is always slightly
+ * bigger than it should be. graphviz-preview-plus does not interfere in
+ * that behavior.
+ *
+ * @param  {object} pRenderedSVG the (jQuery object wrapped) SVG as rendered
+ *                               by GraphViz
+ * @return {nothing}             This function _directly_ manipulates the
+ *                               input SVG
+ */
+export function correctViewBox(pRenderedSVG) {
+    const lWidth = Number.parseFloat(pRenderedSVG.attr("width"));
+    const lHeight = Number.parseFloat(pRenderedSVG.attr("height"));
+
+    // should have been able to use pRenderedSVG.attr to set the viewBox,
+    // however that (jQuery) function executes a toLowerCase (or similar),
+    // As svg attributes are case sensitive this doesn't have any effect.
+    // Hence direct DOM manipulation:
+    const lRenderedSVGDOMElement = pRenderedSVG.get()[0];
+    lRenderedSVGDOMElement.setAttribute("viewBox", `0 0 ${lWidth} ${lHeight}`);
+}
+
+/**
+ * Usualy links in html in atom preview windows are clickable. However,
+ * correct links in svg (in the xlink namespace) aren't, whereas other
+ * browser implementations do.
+ *
+ * This is a workaround for that limitation. It adds a `href` attribute
+ * to each `a` in the svg in the preview window (_not_ to the exported svg!)
+ * that has an`xlink:href` attribute.
+ *
+ * @param  {object} pRenderedSVG the (jQuery object wrapped) SVG as rendered
+ *                               by GraphViz
+ * @return {nothing}             This function _directly_ manipulates the
+ *                               input SVG
+ */
+export function makeLinksClickable(pRenderedSVG) {
+    pRenderedSVG.find("a").each(function() {
+        if (Boolean(this.getAttribute("xlink:href"))) {
+            this.setAttribute("href", this.getAttribute("xlink:href"));
+        }
+    });
+}
+
+/**
+ * GraphViz sometimes uses non-breaking spaces in its SVG. Strict(er) SVG
+ * render programs will bork on this, nbsp's are not defined in XML and hence
+ * not in SVG either. Samples of these stricter programs are safari and
+ * chrome's canvas implementation (probably because html entites don't leak
+ * into those contexts).
+ *
+ * There's two ways around it; define the entity (like
+ * we do in this function) or replace all nbsp entities with &#160.
+ *
+ * Should we have more entities defined here? In theory: yes. In practice: no.
+ * strictly html entities like &copy; _do not_ make these same interpreters
+ * choke - until further notice
+ *
+ * @param  {string} pSVG the svg as a string
+ * @return {string}      the same svg, but with the nbsp entity
+ *                       definition kitted in front of it iff
+ *                       &nbsp; is anywhere in it
+ */
+export function defineEntities(pSVG) {
+    if (pSVG.indexOf('&nbsp;') > -1){
+        return `<!DOCTYPE svg [<!ENTITY nbsp "&#160;">]>${pSVG}`;
+    }
+    return pSVG;
+}
+
+/**
+ * workaround for
+ * https://github.com/sverweij/atom-graphviz-preview-plus/issues/14
+ *
+ * @param  {object} pRenderedSVG      the (jQuery object wrapped) SVG as rendered
+ *                                    by GraphViz
+ * @param  {string} pWorkingDirectory the working directory for the images
+ * @return {nothing}                  (pRenderedSVG is manipulated directly)
+ */
+export function resolveImages(pRenderedSVG, pWorkingDirectory) {
+    const lImages = pRenderedSVG.find('image');
+    if (Boolean(lImages) && resolveImage === null) {
+        resolveImage = require('./resolveImage');
+    }
+    for (let i = 0; i < lImages.length; i++) {
+        lImages[i].href.baseVal = resolveImage(lImages[i].href.baseVal, pWorkingDirectory);
+    }
+}
+
+/* because it's how jQuery does things we'll alow that interesting 'this' for now */
+/* eslint no-invalid-this:0 */

--- a/samples/generates-nbsp-s.gv
+++ b/samples/generates-nbsp-s.gv
@@ -1,0 +1,104 @@
+digraph Q1_CFG {
+    rankdir=TB
+
+    B1
+    [
+        shape = none
+        label = <<table border="0" cellborder = "1" cellspacing="0" bgcolor="white" >
+                    <tr><td border="1" bgcolor="grey" ><font color="white"><B>B1</B></font></td></tr>
+                    <tr><td PORT="l_main"> &iexcl;Main:
+                    </td></tr>
+                    <tr><td PORT="I1" align = "left"> I1
+                    </td></tr>
+                    <tr><td PORT="I2" align = "left"> I2
+                    </td></tr>
+                    <tr><td PORT="I3" align = "left"> I3
+                    </td></tr>
+                    <tr><td PORT="I4" align = "left"> I4
+                    </td></tr>
+                    <tr><td PORT="I5" align = "left"> I5
+                    </td></tr>
+                    <tr><td PORT="I6" align = "left"> I6
+                    </td></tr>
+                </table>>
+    ];
+    B2
+    [
+        shape = none
+        label = <<table border="1" cellspacing="0" bgcolor="white" >
+                    <tr><td border="1" bgcolor="grey" ><font color="white"><B>B2</B></font></td></tr>
+                    <tr><td>
+                    </td></tr>
+                    <tr><td PORT="I7" align = "left"> I7
+                    </td></tr>
+                    <tr><td PORT="I8" align = "left"> I8
+                    </td></tr>
+                </table>>
+    ];
+    B3
+    [
+        shape = none
+        label = <<table border="1" cellspacing="0" bgcolor="white" >
+                    <tr><td border="1" bgcolor="grey" ><font color="white"><B>B3</B></font></td></tr>
+                    <tr><td PORT="l_23"> labelX:
+                    </td></tr>
+                    <tr><td PORT="I9" align = "left">I9
+                    </td></tr>
+                    <tr><td PORT="I10" align = "left"> I10
+                    </td></tr>
+                    <tr><td PORT="I11" align = "left"> I11
+                    </td></tr>
+                    <tr><td PORT="I12" align = "left"> I12
+                    </td></tr>
+                </table>>
+    ];
+    B4
+    [
+        shape = none
+        label = <<table border="1" cellspacing="0" bgcolor="white" >
+                    <tr><td border="1" bgcolor="grey" ><font color="white"><B>B4</B></font></td></tr>
+                    <tr><td PORT="l_63"> labelX:
+                    </td></tr>
+                    <tr><td PORT="I513" align = "left"> I13
+                    </td></tr>
+                </table>>
+    ];
+    B5
+    [
+        shape = none
+        label = <<table border="1" cellspacing="0" bgcolor="white" >
+                    <tr><td border="1" bgcolor="grey" ><font color="white"><B>B5</B></font></td></tr>
+                    <tr><td PORT="l_04" > labelX:
+                    </td></tr>
+                    <tr><td PORT="I14" align = "left"> I14
+                    </td></tr>
+                    <tr><td PORT="I15" align = "left"> I15
+                    </td></tr>
+                </table>>
+    ];
+    B6
+    [
+        shape = none
+        label = <<table border="1" cellspacing="0">
+                    <tr><td border="1" bgcolor="grey" ><font color="white"><B>B6</B></font></td></tr>
+                    <tr><td PORT="l_13" > labelX:
+                    </td></tr>
+                    <tr><td PORT="I16" align = "left"> I16
+                    </td></tr>
+                    <tr><td PORT="I17" align = "left"> I17
+                    </td></tr>
+                    <tr><td PORT="I18" align = "left"> I18
+                    </td></tr>
+                    <tr><td PORT="I19" align = "left"> I19
+                    </td></tr>
+                </table>>
+    ];
+
+    B1 -> B5
+    B3 -> B2
+    B2 -> B2
+    B5 -> B6
+    B3 -> B4
+    B5 -> B3
+    B6 -> B4
+}

--- a/samples/withdpi.dot
+++ b/samples/withdpi.dot
@@ -1,0 +1,6 @@
+digraph {
+    bgcolor=transparent graph [dpi=300];
+    F -> B;
+    A -> Q;
+    A -> B;
+}

--- a/samples/withlink.dot
+++ b/samples/withlink.dot
@@ -1,0 +1,4 @@
+graph {
+  bgcolor=transparent
+  "sverweij.github.io" [URL="http://sverweij.github.io"]
+}

--- a/spec/workarounds-spec.js
+++ b/spec/workarounds-spec.js
@@ -1,0 +1,24 @@
+"use babel";
+
+import * as workarounds from '../lib/workarounds';
+
+describe("workarounds", () => {
+    // describe("correctViewBox", () => true);
+
+    // describe("makeLinksClickable", () => true);
+
+    describe("defineEntities", () => {
+        it("leaves input without nbsp entities in it alone", () => {
+            expect(
+                workarounds.defineEntities("whatever")
+            ).toEqual("whatever");
+        });
+        it("leaves input without nbsp entities in it alone", () => {
+            expect(
+                workarounds.defineEntities("bladie bla &nbsp; bla")
+            ).toEqual("<!DOCTYPE svg [<!ENTITY nbsp \"&#160;\">]>bladie bla &nbsp; bla");
+        });
+    });
+
+    // describe("resolveImages", () => true);
+});


### PR DESCRIPTION
- fixes #24 
- 🔧 : centralizes all workarounds in `workarounds.js`
- adds a few samples for (manual) testing workarounds
- [x] add unit tests for workarounds (easier now they're separated)